### PR TITLE
Fixed wrong capitalization (German/de)

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1658,7 +1658,7 @@ msgstr "Hersteller / Modell"
 #: ../system-config-printer.py:318 ../ui/PrinterPropertiesDialog.ui.h:41
 #: ../ui/PrintersWindow.ui.h:10 ../ui/ServerSettingsDialog.ui.h:15
 msgid "Add"
-msgstr "HInzufügen"
+msgstr "Hinzufügen"
 
 #: ../system-config-printer.py:335 ../ui/PrinterPropertiesDialog.ui.h:88
 #: ../ui/SMBBrowseDialog.ui.h:2


### PR DESCRIPTION
The capitalisation is wrong. Also, is it correct that this button has no accessor-key?