### PR TITLE
Make the combobox text entry child focusable

### DIFF
--- a/ui/ConnectDialog.ui
+++ b/ui/ConnectDialog.ui
@@ -79,7 +79,7 @@
                 <signal name="changed" handler="on_connect_servername_changed" swapped="no"/>
                 <child internal-child="entry">
                   <object class="GtkEntry" id="comboboxtext-entry1">
-                    <property name="can_focus">False</property>
+                    <property name="can_focus">True</property>
                   </object>
                 </child>
                 <accessibility>


### PR DESCRIPTION
By allowing the text entry child of the dialog's combobox to get focus
the user can edit it. This fixes the problem that currently the user
can't write anything in the combobox, so there's no way for someone
to write (for example) the ip where the CUPS server is.
