### PR TITLE
Do not start the applet on GNOME and Cinnamon desktops (Closes: #40)

### DIFF
--- a/print-applet.desktop.in
+++ b/print-applet.desktop.in
@@ -5,6 +5,6 @@ Exec=system-config-printer-applet
 Terminal=false
 Type=Application
 Icon=printer
-NotShowIn=KDE;
+NotShowIn=KDE;GNOME;Cinnamon;
 StartupNotify=false
 X-GNOME-Autostart-Delay=30


### PR DESCRIPTION
{gnome,cinnamon}-settings-daemon are also claiming the D-Bus interfaces
provided by the applet
