### PR TITLE
Add a StartService for systemd based systems

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,4 @@
+1.5.10 changes
+--------------
+
+- printer couldn't be add ( https://bugzilla.redhat.com/show_bug.cgi?id=1419175 ) 


### PR DESCRIPTION
Hi ! 

I noticed that the `Start Service` button didn't work on my ArchLinux system, because I was using **systemd**.  I adapted the program to try launching `org.cups.cupsd.service` through systemd if the system is detected to use systemd (i.e. `/usr/lib/systemd` exists), and use **SysV** otherwise (the current default).

The fix did the job on my machine and the edits are pretty straightforward.  Feel free to ask if something is not clear enough.