### PR TITLE
Replace icons deprecated by GTK 3.0 by non-deprecated ones

### DIFF
--- a/statereason.py
+++ b/statereason.py
@@ -31,9 +31,9 @@ class StateReason:
     ERROR=3
 
     LEVEL_ICON={
-        REPORT: "gtk-dialog-info",
-        WARNING: "gtk-dialog-warning",
-        ERROR: "gtk-dialog-error"
+        REPORT: "dialog-information",
+        WARNING: "dialog-warning",
+        ERROR: "dialog-error"
         }
 
     def __init__(self, printer, reason, ppdcache=None):

--- a/ui/InstallDialog.ui
+++ b/ui/InstallDialog.ui
@@ -97,7 +97,7 @@
               <object class="GtkImage" id="image25">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="icon_name">gtk-dialog-info</property>
+                <property name="icon_name">dialog-information</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/ui/NewPrinterWindow.ui
+++ b/ui/NewPrinterWindow.ui
@@ -579,7 +579,7 @@ ipp://printer.mydomain/ipp</property>
                                               <object class="GtkImage" id="image8">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
-                                                <property name="icon_name">gtk-print-preview</property>
+                                                <property name="icon_name">document-print-preview</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>

--- a/ui/PrinterPropertiesDialog.ui
+++ b/ui/PrinterPropertiesDialog.ui
@@ -117,7 +117,7 @@
                       <object class="GtkImage" id="image44">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="icon_name">gtk-dialog-warning</property>
+                        <property name="icon_name">dialog-warning</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -1147,7 +1147,7 @@ See server settings&lt;/i&gt;</property>
                                   <object class="GtkImage" id="image11">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="icon_name">gtk-go-back</property>
+                                    <property name="icon_name">go-previous</property>
                                   </object>
                                 </child>
                                 <child internal-child="accessible">
@@ -1173,7 +1173,7 @@ See server settings&lt;/i&gt;</property>
                                   <object class="GtkImage" id="image12">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="icon_name">gtk-go-forward</property>
+                                    <property name="icon_name">go-next</property>
                                   </object>
                                 </child>
                                 <child internal-child="accessible">

--- a/ui/WaitWindow.ui
+++ b/ui/WaitWindow.ui
@@ -26,7 +26,7 @@
               <object class="GtkImage" id="image27">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="icon_name">gtk-dialog-info</property>
+                <property name="icon_name">dialog-information</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>


### PR DESCRIPTION
GTK 3.0 has depreated or rename a bunch of icons, follow the new naming
conventions

See: https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html