### PR TITLE
Changes from Ubuntu: Driverless printing support, silence console, minor fixes

### DIFF
--- a/cupshelpers/cupshelpers.py
+++ b/cupshelpers/cupshelpers.py
@@ -553,61 +553,74 @@ class Device:
             if other.is_class:
                 return True
             return False
-        if not self.is_class and (self.type != other.type):
+
+        stype = self.type
+        if stype == "dnssd":
+            if self.uri.find("._ipp") != -1:
+                stype = "dnssdi"
+            elif self.uri.find("._pdl-datastream") != -1:
+                stype = "dnssds"
+            elif self.uri.find("._printer") != -1:
+                stype = "dnssdl"
+        otype = other.type
+        if otype == "dnssd":
+            if other.uri.find("._ipp") != -1:
+                otype = "dnssdi"
+            elif other.uri.find("._pdl-datastream") != -1:
+                otype = "dnssds"
+            elif other.uri.find("._printer") != -1:
+                otype = "dnssdl"
+
+        if not self.is_class and (stype != otype):
             # "hp"/"hpfax" before "usb" before * before "parallel" before
             # "serial"
-            if other.type == "serial":
+            if otype == "serial":
                 return True
-            if self.type == "serial":
+            if stype == "serial":
                 return False
-            if other.type == "parallel":
+            if otype == "parallel":
                 return True
-            if self.type == "parallel":
+            if stype == "parallel":
                 return False
-            if other.type == "hp":
+            if otype == "hp":
                 return False
-            if self.type == "hp":
+            if stype == "hp":
                 return True
-            if other.type == "hpfax":
+            if otype == "hpfax":
                 return False
-            if self.type == "hpfax":
+            if stype == "hpfax":
                 return True
-            if other.type == "dnssd":
+            if otype == "dnssdi":
                 return False
-            if self.type == "dnssd":
+            if stype == "dnssdi":
                 return True
-            if other.type == "socket":
+            if otype == "ipps":
                 return False
-            if self.type == "socket":
+            if stype == "ipps":
                 return True
-            if other.type == "lpd":
+            if otype == "ipp":
                 return False
-            if self.type == "lpd":
+            if stype == "ipp":
                 return True
-            if other.type == "ipps":
+            if otype == "dnssds":
                 return False
-            if self.type == "ipps":
+            if stype == "dnssds":
                 return True
-            if other.type == "ipp":
+            if otype == "socket":
                 return False
-            if self.type == "ipp":
+            if stype == "socket":
                 return True
-            if other.type == "usb":
+            if otype == "dnssdl":
                 return False
-            if self.type == "usb":
+            if stype == "dnssdl":
                 return True
-        if self.type == "dnssd" and other.type == "dnssd":
-            if other.uri.find("._pdl-datastream") != -1: # Socket
+            if otype == "lpd":
                 return False
-            if self.uri.find("._pdl-datastream") != -1:
+            if stype == "lpd":
                 return True
-            if other.uri.find("._printer") != -1: # LPD
+            if otype == "usb":
                 return False
-            if self.uri.find("._printer") != -1:
-                return True
-            if other.uri.find("._ipp") != -1: # IPP
-                return False
-            if self.uri.find("._ipp") != -1:
+            if stype == "usb":
                 return True
         result = bool(self.id) < bool(other.id)
         if not result:

--- a/cupshelpers/ppds.py
+++ b/cupshelpers/ppds.py
@@ -582,10 +582,10 @@ class PPDs:
             try:
                 for each in self.ids["hp"][mdll]:
                     fit[each] = self.FIT_EXACT
-                print ("**** Incorrect IEEE 1284 Device ID: %s" %
-                       self.ids["hp"][mdll])
-                print ("**** Actual ID is MFG:%s;MDL:%s;" % (mfg, mdl))
-                print ("**** Please report a bug against the HPLIP component")
+                _debugprint ("**** Incorrect IEEE 1284 Device ID: %s" %
+                             self.ids["hp"][mdll])
+                _debugprint ("**** Actual ID is MFG:%s;MDL:%s;" % (mfg, mdl))
+                _debugprint ("**** Please report a bug against the HPLIP component")
                 id_matched = True
             except KeyError:
                 pass
@@ -777,8 +777,8 @@ class PPDs:
             if description:
                 id += "DES:%s;" % description
 
-            print ("No ID match for device %s:" % sanitised_uri)
-            print (id)
+            _debugprint ("No ID match for device %s:" % sanitised_uri)
+            _debugprint (id)
 
         return fit
 
@@ -844,7 +844,7 @@ class PPDs:
         _debugprint ("Found PPDs: %s" % str (ppdnamelist))
 
         status = self.getStatusFromFit (fit[ppdnamelist[0]])
-        print ("Using %s (status: %d)" % (ppdnamelist[0], status))
+        _debugprint ("Using %s (status: %d)" % (ppdnamelist[0], status))
         return (status, ppdnamelist[0])
 
     def _findBestMatchPPDs (self, mdls, mdl):

--- a/cupshelpers/ppds.py
+++ b/cupshelpers/ppds.py
@@ -664,6 +664,24 @@ class PPDs:
                     fit[driver] = self.FIT_GENERIC
                     _debugprint ("%s: %s" % (fit[driver], driver))
 
+        # Check by the URI whether our printer is connected via IPP
+        # and if not, remove the PPD entries for driverless printing
+        # (ppdname = "driverless:..." from the list)
+        if (not uri or
+            (not uri.startswith("ipp:") and
+             not uri.startswith("ipps:") and
+             (not uri.startswith("dnssd") or
+              not "._ipp" in uri))):
+            failed = set()
+            for ppdname in fit.keys ():
+                if (ppdname.startswith("driverless:")):
+                    failed.add (ppdname)
+            if (len(failed) > 0):
+                _debugprint ("Removed %s due to non-IPP connection" % failed)
+                for each in failed:
+                    del fit[each]
+            failed = set()
+
         # What about the CMD field of the Device ID?  Some devices
         # have optional units for page description languages, such as
         # PostScript, and they will report different CMD strings

--- a/installpackage.py
+++ b/installpackage.py
@@ -44,7 +44,7 @@ class PackageKit:
         try:
             if self.iface is not None:
                 self.iface.InstallPackageNames(xid, [name],
-                                           "hide-finished,show-warnings",
+                                           "show-progress,show-finished,show-warning",
                                            timeout = 999999)
         except dbus.exceptions.DBusException:
             pass
@@ -53,7 +53,7 @@ class PackageKit:
         try:
             if self.iface is not None:
                 self.iface.InstallProvideFiles(xid, [filename],
-                                               "hide-finished,show-warnings",
+                                               "show-progress,show-finished,show-warning",
                                                timeout = 999999)
         except dbus.exceptions.DBusException:
             pass

--- a/newprinter.py
+++ b/newprinter.py
@@ -3054,10 +3054,16 @@ class NewPrinterGUI(GtkGUI):
                         queue = queue[1:]
                     if queue.startswith("printers/"):
                         queue = queue[9:]
-                if queue != '':
-                    device.menuentry = (_("IPP") + " (%s)" % queue)
+                if 'driverless' in device.info:
+                    drvless = "Driverless "
+                    device.driverless = True
                 else:
-                    device.menuentry = _("IPP")
+                    drvless = ""
+                if queue != '':
+                    device.menuentry = (("%s" + _("IPP") + " (%s)") %
+                                        (drvless, queue))
+                else:
+                    device.menuentry = (("%s" + _("IPP")) % drvless)
             elif device.type == "http" or device.type == "https":
                 device.menuentry = _("HTTP")
             elif device.type == "dnssd" or device.type == "mdns":

--- a/options.py
+++ b/options.py
@@ -19,6 +19,7 @@
 ## along with this program; if not, write to the Free Software
 ## Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from debug import *
 from gi.repository import Gtk
 import cups
 import ppdippstr
@@ -140,7 +141,7 @@ class OptionAlwaysShown(OptionInterface):
 
         if (type(self.widget) == Gtk.ComboBox and
             self.widget.get_model () is None):
-            print("No ComboBox model for %s" % self.name)
+            debugprint("No ComboBox model for %s" % self.name)
             model = Gtk.ListStore (str)
             self.widget.set_model (model)
 
@@ -419,10 +420,10 @@ class OptionSelectOne(Option):
         if selected is not None:
             self.selector.set_active(selected)
         else:
-            print("Unknown value for %s: %s" % (name, value))
-            print("Choices:", supported)
+            debugprint("Unknown value for %s: %s" % (name, value))
+            debugprint("Choices:", supported)
             if len(supported) > 0:
-                print("Selecting from choices:", supported[0])
+                debugprint("Selecting from choices:", supported[0])
                 self.selector.set_active(0)
         self.selector.connect("changed", self.changed)
 

--- a/printerproperties.py
+++ b/printerproperties.py
@@ -1451,7 +1451,7 @@ class PrinterPropertiesDialog(GtkGUI):
         for option in self.printer.attributes.keys ():
             if option in self.server_side_options:
                 continue
-            if option == "output-mode":
+            if option == "output-mode" or option == "media-col":
                 # Not settable
                 continue
             value = self.printer.attributes[option]

--- a/system-config-printer.py
+++ b/system-config-printer.py
@@ -948,7 +948,7 @@ class GUI(GtkGUI):
                               'i-network-printer'),
                          'smb-printer':
                              (_("Network print share"),
-                              'printer'),
+                              'i-network-printer'),
                          'network-printer':
                              (_("Network printer"),
                               'i-network-printer'),
@@ -971,14 +971,23 @@ class GUI(GtkGUI):
                     type = 'local-class'
                 else:
                     (scheme, rest) = urllib.parse.splittype (object.device_uri)
-                    if scheme == 'ipp':
-                        type = 'ipp-printer'
+                    if scheme in ['ipp', 'ipps']:
+                        if rest.startswith("//localhost"): # IPP-over-USB
+                            type = 'local-printer'
+                        else: # IPP network printer
+                            type = 'ipp-printer'
                     elif scheme == 'smb':
                         type = 'smb-printer'
                     elif scheme == 'hpfax':
                         type = 'local-fax'
-                    elif scheme in ['socket', 'lpd']:
+                    elif scheme in ['socket', 'lpd', 'dnssd']:
                         type = 'network-printer'
+                    elif object.device_uri.startswith('hp:/net/'):
+                        type = 'network-printer'
+                    elif object.device_uri.startswith('hpfax:/net/'):
+                        type = 'network-printer'
+                    elif scheme == 'implicitclass': # cups-browsed-discovered
+                        type = 'discovered-printer'
 
                 (tip, icon) = PRINTER_TYPE[type]
                 (result, w, h) = Gtk.icon_size_lookup (Gtk.IconSize.DIALOG)

--- a/ui/NewPrinterWindow.ui
+++ b/ui/NewPrinterWindow.ui
@@ -1324,10 +1324,12 @@ ipp://printer.mydomain/ipp</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="shadow_type">in</property>
+                                <property name="min_content_height">120</property>
                                 <child>
                                   <object class="GtkTreeView" id="tvNPDeviceURIs">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
+                                    <property name="headers_visible">False</property>
                                     <signal name="cursor-changed" handler="on_tvNPDeviceURIs_cursor_changed" swapped="no"/>
                                     <child internal-child="selection">
                                       <object class="GtkTreeSelection" id="treeview-selection2"/>

--- a/xml/preferreddrivers.xml
+++ b/xml/preferreddrivers.xml
@@ -83,6 +83,10 @@
     <!-- END OF GENERIC DRIVERS -->
     <!-- now fit is either exact-cmd, exact, or close -->
 
+    <drivertype name="driverless">
+      <ppdname match="driverless:"/>
+    </drivertype>
+
     <drivertype name="cups">
       <ppdname match="drv:///sample.drv/"/>
     </drivertype>
@@ -292,6 +296,7 @@
     <printer>
       <!-- For all printers -->
       <drivers>
+	<drivertype>driverless</drivertype>
 	<drivertype>manufacturer-cmd</drivertype>
 	<drivertype>foomatic-recommended-nonpostscript</drivertype>
 	<drivertype>manufacturer*</drivertype>


### PR DESCRIPTION
This is the collection of improvements an fixes which I have done on system-config-printer during the last few months as part of the Ubuntu packaging.
These are all small independent patches which should all be interesting for upstream, but they also should work if only a part gets adopted.
Here is an overview of the changes:

- Display correct icons in the main window.
Fixed display of printer icons in the main window, now the icons correctly represent local printers and network prrinters taking into account all recent changes in CUPS and cups-filters.

- Prefer driverless PPDs if suitable
Prioritize auto-generated PPD files for driverless printing, as they poll the properties from the printer, and so they represent the printer best.

- Do not use driverless PPDs on non-IPP connections
Make sure that auto-generated PPD files for driverless printing are not used when another connection type than IPP is used for the printer.  When printing driverless option settings are sent to the printers as IPP attributes.

- Prioritize IPP in the printer connection type list.
As IPP is the most modern and sophisticated network printing protocol and especially supports driverless printing, let IPP options show first in the list of possible connections for a discovered network printer. Only HPLIP stays more highly prioritized as for HP multi-function devices as HPLIP print queue is required for the scanner to work.

- Mark IPP printers discovered by the "driverless" utility of cups-filters.
If an IPP printer is discovered by the "driverless" utility from cups-filters, give it a "driverless" mark in the list of possible connections for the network printers, to guide the user to an easy way to set up the printer.

- Improved identifying network printers as being from the same host.
In some cases two entries under the discovered network printers were not identified as coming from the same host (= physical printer). This happened especially with Zeroconf-provided host names with ".local".

- Fix size of connection type list widget in new-printer window.
Fixed connection type list for detected/discovered printers on the "Devices" tab of the new-printer window. The list was too small so that the options were not visible.

- Allow setup of SMB printers without Samba client software installed.
Install the software as soon as it is needed for browsing the network and using the printer

- Do not exit the installpackage helper program too early
Do not exit when installing a package via installpackage.py until the package is completely installed.

- Silence console output
Always use the _debugprint() function in cupshelpers/ppds.py, to silence console output.

- Silence more console output
Let options.py use debugprint() to silence console output.

- Suppress the display of the "media-col" attribute since this is not a user-configurable option
The "media-col" IPP attribute is a list of all available media settings, not the media which the user actually chooses. So it should not show as a user-settable option.
