### PR TITLE
workaround Namespace GnomeKeyring not available

### DIFF
--- a/jobviewer.py
+++ b/jobviewer.py
@@ -57,7 +57,7 @@ try:
     gi.require_version('GnomeKeyring', '1.0')
     from gi.repository import GnomeKeyring
     USE_KEYRING=True
-except ImportError:
+except (ImportError, ValueError):
     USE_KEYRING=False
 
 import gettext


### PR DESCRIPTION
refs:
https://bugzilla.redhat.com/show_bug.cgi?id=1400947
https://bugs.archlinux.org/task/52607

fixes #51 