### PR TITLE
build: Install appstream metadata to non-deprecated location

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -263,7 +263,7 @@ desktop_in_files = $(desktop_DATA:.desktop=.desktop.in)
 
 @INTLTOOL_XML_RULE@
 
-appdatadir = $(datadir)/appdata
+appdatadir = $(datadir)/metainfo
 appdata_in_files = system-config-printer.appdata.xml.in
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 


### PR DESCRIPTION
`/usr/share/metainfo/` has been the [preferred location](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location) for appstream metadata since appstream 0.9.4 a year and a half ago