### PR TITLE
Use ValueError instead of ImportError to catch exception when importi…

### DIFF
--- a/jobviewer.py
+++ b/jobviewer.py
@@ -57,7 +57,7 @@ try:
     gi.require_version('Secret', '1')
     from gi.repository import Secret
     USE_SECRET=True
-except ImportError:
+except ValueError:
     USE_SECRET=False
 
 import gettext


### PR DESCRIPTION
…ng GIR bindings

When importing specific version of GIR bindings, the ValueError
exception is raised instead of ImportError.

This should make libsecret optional as intended

Fixes: #94