### PR TITLE
Fallback to using LC_CTYPE if LC_MESSAGES is empty and fix _language use

### DIFF
--- a/scp-dbus-service.py
+++ b/scp-dbus-service.py
@@ -471,6 +471,8 @@ class ConfigPrinting(dbus.service.Object):
         self._jobappletpath = None
         self._ppds = None
         self._language = locale.getlocale (locale.LC_MESSAGES)[0]
+        if not self._language:
+            self._language = locale.getlocale (locale.LC_CTYPE)[0]
 
     def destroy (self):
         self._cupsconn.destroy ()
@@ -511,7 +513,7 @@ class ConfigPrinting(dbus.service.Object):
     def GetBestDrivers(self, device_id, device_make_and_model, device_uri,
                    reply_handler, error_handler):
         GetBestDriversRequest (device_id, device_make_and_model, device_uri,
-                               self._cupsconn, self._language[0],
+                               self._cupsconn, self._language,
                                reply_handler, error_handler)
 
     @dbus.service.method(dbus_interface=CONFIG_IFACE,


### PR DESCRIPTION
On openSUSE, LC_MESSAGES is not set by default, so fallback to LC_CTYPE in
that case.

Also, self._language is not a list (unlike in other classes) but the language
itself, so if we get the first element, we would be getting the first letter,
not the language.