### PR TITLE
Fix TypeError raised by debugprint call

### DIFF
--- a/options.py
+++ b/options.py
@@ -421,7 +421,7 @@ class OptionSelectOne(Option):
             self.selector.set_active(selected)
         else:
             debugprint("Unknown value for %s: %s" % (name, value))
-            debugprint("Choices:", supported)
+            debugprint("Choices: %s" % (supported))
             if len(supported) > 0:
                 debugprint("Selecting from choices:", supported[0])
                 self.selector.set_active(0)


### PR DESCRIPTION
- this error is caused by typo in options.py:424 debugprint call
- debugprint function takes only one parameter so i think it should
have been formated string
- fix https://bugzilla.redhat.com/show_bug.cgi?id=1619593