### PR TITLE
dbus: remove deprecated at_console statement

### DIFF
--- a/dbus/com.redhat.NewPrinterNotification.conf
+++ b/dbus/com.redhat.NewPrinterNotification.conf
@@ -2,27 +2,16 @@
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-	<policy at_console="true">
-		<allow own="com.redhat.NewPrinterNotification"/>
-	</policy>
-
-	<policy user="root">
-		<allow own="com.redhat.NewPrinterNotification"/>
-	</policy>
-
 	<policy user="root">
 		<allow send_destination="com.redhat.NewPrinterNotification"
 		       send_interface="com.redhat.NewPrinterNotification"/>
 	</policy>
 
 	<policy context="default">
-		<deny own="com.redhat.NewPrinterNotification"/>
+		<allow own="com.redhat.NewPrinterNotification"/>
 
 		<deny send_destination="com.redhat.NewPrinterNotification"
 		      send_interface="com.redhat.NewPrinterNotification"/>
-	</policy>
-
-	<policy context="default">
 		<allow send_destination="com.redhat.NewPrinterNotification"
 		       send_interface="org.freedesktop.DBus.Introspectable" />
 		<allow send_destination="com.redhat.NewPrinterNotification"

--- a/dbus/com.redhat.PrinterDriversInstaller.conf
+++ b/dbus/com.redhat.PrinterDriversInstaller.conf
@@ -2,27 +2,16 @@
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-	<policy at_console="true">
-		<allow own="com.redhat.PrinterDriversInstaller"/>
-	</policy>
-
-	<policy user="root">
-		<allow own="com.redhat.PrinterDriversInstaller"/>
-	</policy>
-
 	<policy user="root">
 		<allow send_destination="com.redhat.PrinterDriversInstaller"
 		       send_interface="com.redhat.PrinterDriversInstaller"/>
 	</policy>
 
 	<policy context="default">
-		<deny own="com.redhat.PrinterDriversInstaller"/>
+		<allow own="com.redhat.PrinterDriversInstaller"/>
 
 		<deny send_destination="com.redhat.PrinterDriversInstaller"
 		      send_interface="com.redhat.PrinterDriversInstaller"/>
-	</policy>
-
-	<policy context="default">
 		<allow send_destination="com.redhat.PrinterDriversInstaller"
 		       send_interface="org.freedesktop.DBus.Introspectable" />
 		<allow send_destination="com.redhat.PrinterDriversInstaller"


### PR DESCRIPTION
As described in [0], this likely did not have the intended effect, so
simply remove it. The change in behavior is that up until this patch
it would be possible for root and any non-system user to potentially
own the system-config-printer dbus names. Now this is extended to also
allow any system user.

[0]: <https://www.spinics.net/lists/linux-bluetooth/msg75267.html>

Signed-off-by: Tom Gundersen <teg@jklm.no>
CC: David Herrmann <dh.herrmann@gmail.com>