### PR TITLE
Fix troubleshoot

### DIFF
--- a/authconn.py
+++ b/authconn.py
@@ -233,6 +233,10 @@ class Connection:
 
     def _authloop (self, fname, fn, *args, **kwds):
         self._passes = 0
+        # remove signature if dbus is not being used and signature is provided
+        if not self._using_polkit():
+            kwds.pop('signature', None)
+
         c = self._connection
         retry = False
         while True:

--- a/cupspk.py
+++ b/cupspk.py
@@ -99,6 +99,8 @@ class Connection:
 
     def _call_with_pk_and_fallback(self, use_fallback, pk_function_name, pk_args, fallback_function, *args, **kwds):
         pk_function = None
+        # take signature from kwds if is provided
+        dbus_args_signature = kwds.pop('signature', None)
 
         if not use_fallback:
             cups_pk = self._get_cups_pk()
@@ -116,7 +118,7 @@ class Connection:
         while True:
             try:
                 # FIXME: async call or not?
-                pk_retval = pk_function(*pk_args)
+                pk_retval = pk_function(*pk_args, signature = dbus_args_signature)
 
                 # if the PK call has more than one return values, we pop the
                 # first one as the error message

--- a/troubleshoot/DeviceListed.py
+++ b/troubleshoot/DeviceListed.py
@@ -86,6 +86,7 @@ class DeviceListed(Question):
             self.authconn = answers['_authenticated_connection']
             try:
                 self.op = TimedOperation (self.authconn.getDevices,
+                                          kwargs={'signature': 'iiasas'},
                                           parent=parent)
                 devices = self.op.run ()
                 devices_list = []

--- a/troubleshoot/ErrorLogFetch.py
+++ b/troubleshoot/ErrorLogFetch.py
@@ -69,11 +69,11 @@ class ErrorLogFetch(Question):
             with NamedTemporaryFile (delete=False) as tmpf:
                 success = False
                 try:
-                    c.getFile ('/admin/log/error_log', tmpf.file)
+                    c.getFile ('/admin/log/error_log', file = tmpf)
                     success = True
                 except cups.HTTPError:
                     try:
-                        os.remove (tmpf.file)
+                        os.remove (tmpf.name)
                     except OSError:
                         pass
 

--- a/troubleshoot/__init__.py
+++ b/troubleshoot/__init__.py
@@ -23,6 +23,8 @@ from gi.repository import Gdk
 from gi.repository import Gtk
 import pprint
 import sys
+import datetime
+import time
 import traceback
 
 if __name__ == "__main__":
@@ -102,7 +104,9 @@ class Troubleshooter:
 
         self.questions = []
         self.question_answers = []
-        self.answers = {}
+        # timestamp should be accessible through whole troubleshoot
+        now = datetime.datetime.fromtimestamp (time.time ())
+        self.answers = {'error_log_timestamp': now.strftime ("%F %T")}
         self.moving_backwards = False
 
         main.show_all ()


### PR DESCRIPTION
- allow timestamp to be accessible through whole
troubleshoot process
- fix dbus call to get devices from cups
- if dbus method call has empty array as an argument then it needs
to have explicitly set signature
- fix some errors with temporary files
- fix rhbz1577082