### PR TITLE
Remove more uses of deprecated GObject.SIGNAL_RUN_LAST

### DIFF
--- a/scp-dbus-service.py
+++ b/scp-dbus-service.py
@@ -60,8 +60,8 @@ GLib.set_prgname("system-config-printer")
 
 class FetchedPPDs(GObject.GObject):
     __gsignals__ = {
-        'ready': (GObject.SIGNAL_RUN_LAST, None, ()),
-        'error': (GObject.SIGNAL_RUN_LAST, None,
+        'ready': (GObject.SignalFlags.RUN_LAST, None, ()),
+        'error': (GObject.SignalFlags.RUN_LAST, None,
                   (GObject.TYPE_PYOBJECT,))
         }
 


### PR DESCRIPTION
9ae2308a8e02527b34f6216162c88ebae04d8dc4 removed many of these but these two were left over.

@pwithnall noticed this when I was backporting that patch to Endless OS. I have not actually tested this change.